### PR TITLE
Add migration simulation helpers and improve robustness

### DIFF
--- a/migration_simulation.py
+++ b/migration_simulation.py
@@ -1,65 +1,266 @@
+"""Simulation utilities for exploring migration-driven macro scenarios.
+
+This module exposes the :class:`MigrationSimulator` – a light-weight engine that
+tracks country level population and GDP per capita trajectories – along with a
+set of helpers that make it easier to transform raw projection files into the
+dictionary inputs required by the simulator.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple
+
 import pandas as pd
-import numpy as np
+
+logger = logging.getLogger(__name__)
+
+ProjectionDict = Dict[Tuple[str, int], float]
+MigrationFlowsDict = Dict[int, List[Tuple[str, str, float]]]
+
 
 class MigrationSimulator:
-    """
-    Simulates country-level population and GDP trajectories under migration scenarios.
-    """
-    def __init__(self,
-                 base_df: pd.DataFrame,
-                 pop_proj: dict,      # {(country, year): pop_growth_rate}
-                 gdp_proj: dict,      # {(country, year): gdp_per_cap_growth_rate}
-                 migration_flows: dict,# {year: [(origin, dest, count), ...]}
-                 init_prod: float=0.5,
-                 prod_step: float=0.1):
-        # Base year is the max Year in base_df
-        self.year = int(base_df['Year'].max())
-        self.state = {row['Country']: {
-                          'pop': row['Total_Population'],
-                          'gdp_pc': row['GDP'] / row['Total_Population']
-                      } for _, row in base_df.iterrows()}
-        self.pop_proj = pop_proj
-        self.gdp_proj = gdp_proj
-        self.flows   = migration_flows
-        self.cohorts = {c: [] for c in self.state}
-        self.init_prod   = init_prod
-        self.prod_step   = prod_step
-        self.history = []
+    """Simulates country-level population and GDP trajectories under migration scenarios."""
 
-    def step(self):
-        y = self.year + 1
-        new_state = {}
-        # 1) Natural growth
-        for c, st in self.state.items():
-            pg = self.pop_proj.get((c, y), 0.0)
-            gpg = self.gdp_proj.get((c, y), 0.0)
-            pop = st['pop'] * (1 + pg)
-            gdp_pc = st['gdp_pc'] * (1 + gpg)
-            new_state[c] = {'pop': pop, 'gdp_pc': gdp_pc}
-        # 2) Migration flows
-        for orig, dest, cnt in self.flows.get(y, []):
-            cnt = min(cnt, new_state[orig]['pop'])
-            new_state[orig]['pop'] -= cnt
-            new_state[dest]['pop'] += cnt
-            self.cohorts[dest].append({'year': y, 'count': cnt, 'prod': self.init_prod})
-        # 3) Update cohorts’ productivity and compute GDP
-        year_rec = {'Year': y}
-        for c, st in new_state.items():
-            # update cohort productivity
-            for coh in self.cohorts[c]:
-                coh['prod'] = min(1.0, coh['prod'] + self.prod_step)
-            # effective pop = pop − ∑(1−prod)*count
-            shortfall = sum((1-coh['prod'])*coh['count'] for coh in self.cohorts[c])
-            eff_pop = st['pop'] - shortfall
-            gdp = eff_pop * st['gdp_pc']
-            year_rec[f'{c}_pop'] = st['pop']
-            year_rec[f'{c}_gdp_pc'] = st['gdp_pc']
-            year_rec[f'{c}_gdp'] = gdp
-        self.history.append(year_rec)
+    REQUIRED_COLUMNS = {"Country", "Year", "Total_Population", "GDP"}
+
+    def __init__(
+        self,
+        base_df: pd.DataFrame,
+        pop_proj: ProjectionDict,
+        gdp_proj: ProjectionDict,
+        migration_flows: MigrationFlowsDict,
+        init_prod: float = 0.5,
+        prod_step: float = 0.1,
+    ) -> None:
+        validate_base_dataframe(base_df, self.REQUIRED_COLUMNS)
+
+        self.year = int(base_df["Year"].max())
+        self.state: Dict[str, Dict[str, float]] = {}
+        for _, row in base_df.iterrows():
+            country = row["Country"]
+            pop = float(row["Total_Population"])
+            if pop <= 0:
+                raise ValueError(
+                    f"Country '{country}' has non-positive population ({pop}). "
+                    "Ensure base data represents living population counts."
+                )
+            gdp_value = float(row["GDP"])
+            gdp_per_cap = gdp_value / pop if gdp_value else 0.0
+            self.state[country] = {"pop": pop, "gdp_pc": gdp_per_cap}
+
+        self.pop_proj = dict(pop_proj)
+        self.gdp_proj = dict(gdp_proj)
+        self.flows = {int(year): list(flows) for year, flows in migration_flows.items()}
+        self.cohorts: Dict[str, List[Dict[str, float]]] = {c: [] for c in self.state}
+        self.init_prod = float(init_prod)
+        self.prod_step = float(prod_step)
+        self.history: List[Dict[str, float]] = []
+
+    def step(self) -> None:
+        year = self.year + 1
+        new_state: Dict[str, Dict[str, float]] = {}
+
+        for country, state in self.state.items():
+            pop_growth = self.pop_proj.get((country, year), 0.0)
+            gdp_growth = self.gdp_proj.get((country, year), 0.0)
+            pop = state["pop"] * (1 + pop_growth)
+            gdp_pc = state["gdp_pc"] * (1 + gdp_growth)
+            new_state[country] = {"pop": pop, "gdp_pc": gdp_pc}
+
+        for origin, destination, count in self.flows.get(year, []):
+            if count <= 0:
+                logger.debug(
+                    "Skipping non-positive migration flow %s -> %s: %s",
+                    origin,
+                    destination,
+                    count,
+                )
+                continue
+
+            if origin not in new_state:
+                logger.warning("Origin country '%s' missing from state; skipping flow", origin)
+                continue
+            if destination not in new_state:
+                logger.warning(
+                    "Destination country '%s' missing from state; skipping flow",
+                    destination,
+                )
+                continue
+
+            available = new_state[origin]["pop"]
+            move = min(count, available)
+            if move <= 0:
+                continue
+
+            new_state[origin]["pop"] -= move
+            new_state[destination]["pop"] += move
+            self.cohorts.setdefault(destination, [])
+            self.cohorts[destination].append({"year": year, "count": move, "prod": self.init_prod})
+
+        year_record: Dict[str, float] = {"Year": year}
+        for country, state in new_state.items():
+            for cohort in self.cohorts[country]:
+                cohort["prod"] = min(1.0, cohort["prod"] + self.prod_step)
+
+            shortfall = sum((1 - cohort["prod"]) * cohort["count"] for cohort in self.cohorts[country])
+            effective_population = state["pop"] - shortfall
+            gdp = effective_population * state["gdp_pc"]
+
+            year_record[f"{country}_pop"] = state["pop"]
+            year_record[f"{country}_gdp_pc"] = state["gdp_pc"]
+            year_record[f"{country}_gdp"] = gdp
+
+        self.history.append(year_record)
         self.state = new_state
-        self.year = y
+        self.year = year
 
-    def run(self, end_year):
+    def run(self, end_year: int) -> pd.DataFrame:
         while self.year < end_year:
             self.step()
         return pd.DataFrame(self.history)
+
+
+def validate_base_dataframe(df: pd.DataFrame, required_columns: Iterable[str]) -> None:
+    missing = set(required_columns) - set(df.columns)
+    if missing:
+        raise ValueError(
+            "Base dataframe is missing required columns: " + ", ".join(sorted(missing))
+        )
+
+    if df["Country"].isna().any():
+        raise ValueError("Base dataframe contains rows with missing country names.")
+
+    if df["GDP"].isna().any():
+        raise ValueError("Base dataframe contains rows with missing GDP values.")
+
+    if df["Total_Population"].isna().any():
+        raise ValueError("Base dataframe contains rows with missing population values.")
+
+
+def dataframe_to_projection_dict(
+    df: pd.DataFrame,
+    *,
+    country_col: str,
+    year_col: str,
+    value_col: str,
+    value_transform: Optional[Callable[[float], float]] = None,
+    dropna: bool = True,
+) -> ProjectionDict:
+    if value_transform is None:
+        value_transform = lambda value: value  # type: ignore[return-value]
+
+    projection: ProjectionDict = {}
+    for _, row in df.iterrows():
+        country = row[country_col]
+        if not isinstance(country, str) or not country.strip():
+            continue
+
+        year_raw = row[year_col]
+        if pd.isna(year_raw):
+            continue
+        year = int(year_raw)
+
+        value = row[value_col]
+        if dropna and pd.isna(value):
+            continue
+
+        numeric_value = float(value_transform(float(value)))
+        projection[(country, year)] = numeric_value
+    return projection
+
+
+def load_projection_csv(
+    path: str,
+    *,
+    country_col: str,
+    year_col: str,
+    value_col: str,
+    filters: Optional[Mapping[str, Iterable]] = None,
+    value_transform: Optional[Callable[[float], float]] = None,
+    dropna: bool = True,
+    read_csv_kwargs: Optional[Mapping[str, object]] = None,
+) -> ProjectionDict:
+    kwargs = dict(read_csv_kwargs or {})
+    df = pd.read_csv(path, **kwargs)
+    if filters:
+        for column, allowed in filters.items():
+            df = df[df[column].isin(allowed)]
+    return dataframe_to_projection_dict(
+        df,
+        country_col=country_col,
+        year_col=year_col,
+        value_col=value_col,
+        value_transform=value_transform,
+        dropna=dropna,
+    )
+
+
+def migration_flows_from_dataframe(
+    df: pd.DataFrame,
+    *,
+    origin_col: str,
+    destination_col: str,
+    year_col: str,
+    flow_col: str,
+    dropna: bool = True,
+) -> MigrationFlowsDict:
+    flows: MigrationFlowsDict = {}
+    for _, row in df.iterrows():
+        origin = row[origin_col]
+        destination = row[destination_col]
+        count = row[flow_col]
+        year_raw = row[year_col]
+
+        if dropna and (
+            pd.isna(origin)
+            or pd.isna(destination)
+            or pd.isna(count)
+            or pd.isna(year_raw)
+        ):
+            continue
+
+        if not isinstance(origin, str) or not isinstance(destination, str):
+            continue
+
+        year = int(year_raw)
+        count_value = float(count)
+        if count_value < 0:
+            raise ValueError("Migration counts must be non-negative.")
+
+        flows.setdefault(year, []).append((origin, destination, count_value))
+    return flows
+
+
+def load_migration_flows_csv(
+    path: str,
+    *,
+    origin_col: str,
+    destination_col: str,
+    year_col: str,
+    flow_col: str,
+    dropna: bool = True,
+    read_csv_kwargs: Optional[Mapping[str, object]] = None,
+) -> MigrationFlowsDict:
+    kwargs = dict(read_csv_kwargs or {})
+    df = pd.read_csv(path, **kwargs)
+    return migration_flows_from_dataframe(
+        df,
+        origin_col=origin_col,
+        destination_col=destination_col,
+        year_col=year_col,
+        flow_col=flow_col,
+        dropna=dropna,
+    )
+
+
+__all__ = [
+    "MigrationSimulator",
+    "ProjectionDict",
+    "MigrationFlowsDict",
+    "dataframe_to_projection_dict",
+    "load_projection_csv",
+    "migration_flows_from_dataframe",
+    "load_migration_flows_csv",
+    "validate_base_dataframe",
+]

--- a/run_migration_simulation.py
+++ b/run_migration_simulation.py
@@ -1,28 +1,104 @@
-# run_migration_simulation.py
+"""Example entry point for running the :class:`MigrationSimulator`.
+
+The helper utilities provided in :mod:`migration_simulation` make it easy to
+transform CSV projections into the dictionaries expected by the simulator.  This
+script demonstrates how those utilities can be composed to build a simple
+scenario using the historical data already present in the repository.  Replace
+the example data loading logic with your own projection sources when running a
+full analysis.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
 import pandas as pd
-from migration_simulation import MigrationSimulator
 
-# Load base data (historical latest year) from the repository CSV
-base_df = pd.read_csv("Data_GDP_Pop_by_Country_1960_Countries_only.csv")
-base_year = 2023  # for example, if 2020 is last year in data
-base_data = base_df[base_df['Year'] == base_year]  # filter latest year
-
-# Load or define projection inputs
-pop_growth = pd.read_csv(
-    "https://population.un.org/wpp/Download/Files/1_Indicators%20of%20Population/WPP2022_POPPROJ1DT.csv"
+from migration_simulation import (
+    MigrationSimulator,
+    MigrationFlowsDict,
+    ProjectionDict,
+    dataframe_to_projection_dict,
+    migration_flows_from_dataframe,
+    validate_base_dataframe,
 )
-gdp_growth = pd.read_csv( 
-    "https://www.imf.org/external/datamapper/export/csv.php?indicator=NGDPDPC"  # function or manual input
 
-)
-migration_flows = load_migration_flows("migration_flows.csv")    # or define a dictionary
-integration_params = {"init_productivity": 0.5, "annual_increase": 0.1}
+BASE_DATA_PATH = Path("Data_GDP_Pop_by_Country_1960_Countries_only.csv")
+OUTPUT_PATH = Path("simulation_results_example.csv")
 
-# Initialize simulator
-sim = MigrationSimulator(base_data, pop_growth, gdp_growth, migration_flows, integration_params)
-# Run simulation from base_year+1 to 2050
-results_df = sim.run(end_year=2050)
 
-# Save or print results
-results_df.to_csv("simulation_results_2020_2050.csv", index=False)
-print("Global GDP in 2050:", results_df[results_df['Year']==2050]['GDP'].sum())
+def build_example_inputs(
+    base_csv: Path,
+) -> Tuple[pd.DataFrame, ProjectionDict, ProjectionDict, MigrationFlowsDict]:
+    """Construct a minimal set of simulator inputs from the repository dataset."""
+
+    base_df = pd.read_csv(base_csv)
+    latest_year = int(base_df["Year"].max())
+    snapshot = base_df[base_df["Year"] == latest_year].copy()
+    validate_base_dataframe(snapshot, MigrationSimulator.REQUIRED_COLUMNS)
+
+    history = base_df.sort_values(["Country", "Year"]).copy()
+    history["gdp_pc"] = history["GDP"] / history["Total_Population"]
+    history["pop_growth"] = history.groupby("Country")["Total_Population"].pct_change()
+    history["gdp_pc_growth"] = history.groupby("Country")["gdp_pc"].pct_change()
+
+    pop_growth = dataframe_to_projection_dict(
+        history.dropna(subset=["pop_growth"]),
+        country_col="Country",
+        year_col="Year",
+        value_col="pop_growth",
+    )
+    gdp_growth = dataframe_to_projection_dict(
+        history.dropna(subset=["gdp_pc_growth"]),
+        country_col="Country",
+        year_col="Year",
+        value_col="gdp_pc_growth",
+    )
+
+    migration_df = pd.DataFrame(
+        [
+            {
+                "Year": latest_year + 1,
+                "Origin": "United States",
+                "Destination": "Canada",
+                "Migrants": 50_000,
+            },
+            {
+                "Year": latest_year + 1,
+                "Origin": "Canada",
+                "Destination": "United States",
+                "Migrants": 30_000,
+            },
+        ]
+    )
+    migration_flows = migration_flows_from_dataframe(
+        migration_df,
+        origin_col="Origin",
+        destination_col="Destination",
+        year_col="Year",
+        flow_col="Migrants",
+    )
+
+    return snapshot, pop_growth, gdp_growth, migration_flows
+
+
+def main() -> None:
+    base_data, pop_growth, gdp_growth, migration_flows = build_example_inputs(BASE_DATA_PATH)
+
+    simulator = MigrationSimulator(
+        base_data,
+        pop_growth=pop_growth,
+        gdp_proj=gdp_growth,
+        migration_flows=migration_flows,
+        init_prod=0.5,
+        prod_step=0.1,
+    )
+    end_year = simulator.year + 10
+    results = simulator.run(end_year=end_year)
+    results.to_csv(OUTPUT_PATH, index=False)
+    print(f"Saved example simulation covering up to {end_year} to {OUTPUT_PATH}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_migration_helpers.py
+++ b/tests/test_migration_helpers.py
@@ -1,0 +1,89 @@
+import pandas as pd
+import pytest
+
+from migration_simulation import (
+    MigrationSimulator,
+    dataframe_to_projection_dict,
+    migration_flows_from_dataframe,
+    validate_base_dataframe,
+)
+
+
+def test_dataframe_to_projection_dict_basic():
+    df = pd.DataFrame(
+        {
+            "Country": ["A", "A", "B"],
+            "Year": [2020, 2021, 2021],
+            "Growth": [0.01, 0.02, 0.03],
+        }
+    )
+
+    projection = dataframe_to_projection_dict(
+        df,
+        country_col="Country",
+        year_col="Year",
+        value_col="Growth",
+    )
+
+    assert projection[("A", 2020)] == pytest.approx(0.01)
+    assert projection[("A", 2021)] == pytest.approx(0.02)
+    assert projection[("B", 2021)] == pytest.approx(0.03)
+
+
+def test_migration_flows_from_dataframe_skips_missing_and_requires_non_negative():
+    df = pd.DataFrame(
+        {
+            "Origin": ["A", "A", None],
+            "Destination": ["B", "C", "D"],
+            "Year": [2025, 2025, 2025],
+            "Migrants": [100, -50, 200],
+        }
+    )
+
+    flows = migration_flows_from_dataframe(
+        df.drop(index=1),
+        origin_col="Origin",
+        destination_col="Destination",
+        year_col="Year",
+        flow_col="Migrants",
+    )
+
+    assert flows == {2025: [("A", "B", 100.0)]}
+
+    with pytest.raises(ValueError):
+        migration_flows_from_dataframe(
+            df,
+            origin_col="Origin",
+            destination_col="Destination",
+            year_col="Year",
+            flow_col="Migrants",
+        )
+
+
+def test_validate_base_dataframe_and_simulator_handles_unknown_destinations():
+    base_df = pd.DataFrame(
+        {
+            "Country": ["A", "B"],
+            "Year": [2020, 2020],
+            "Total_Population": [1_000, 500],
+            "GDP": [1000, 600],
+        }
+    )
+
+    validate_base_dataframe(base_df, MigrationSimulator.REQUIRED_COLUMNS)
+
+    pop_proj = {("A", 2021): 0.0, ("B", 2021): 0.0}
+    gdp_proj = {("A", 2021): 0.0, ("B", 2021): 0.0}
+    flows = {2021: [("A", "B", 100), ("B", "C", 50)]}
+
+    sim = MigrationSimulator(base_df, pop_proj, gdp_proj, flows, init_prod=0.5, prod_step=0.5)
+    sim.step()
+
+    # 100 people move from A to B; flow to missing destination is skipped
+    assert sim.state["A"]["pop"] == pytest.approx(900)
+    assert sim.state["B"]["pop"] == pytest.approx(600)
+
+    with pytest.raises(ValueError):
+        invalid_base = base_df.copy()
+        invalid_base.loc[0, "Total_Population"] = 0
+        MigrationSimulator(invalid_base, pop_proj, gdp_proj, {})


### PR DESCRIPTION
## Summary
- harden `MigrationSimulator` with input validation, safer flow handling, and typed helper exports
- add utilities for turning projection and migration CSVs into simulator dictionaries and refresh the example runner to use them
- introduce regression tests for the helpers and ensure tests can import project modules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c2d032e0a48320a1024a845ea21dde